### PR TITLE
hofx for realtime hrrrv5 3km runs

### DIFF
--- a/scripts/exrrfs_ungrib.sh
+++ b/scripts/exrrfs_ungrib.sh
@@ -21,23 +21,27 @@ if [[ "${prefix}" == "GFS" ]]; then
   ${cpreq} ${COMINgfs}/gfs.${CDATEin:0:8}/${CDATEin:8:2}/gfs.t${CDATEin:8:2}z.pgrb2.0p25.f${fstr} GRIBFILE.AAA
 elif [[ "${prefix}" == "RAP" ]]; then
   fstr=$(printf %02d ${FHRin})
-  GRIB_FILE=${COMINrap}/rap.${CDATEin:0:8}/rap.t${CDATEin:8:2}z.wrfnatf${fstr}.grib2
+  GRIBFILE=${COMINrap}/rap.${CDATEin:0:8}/rap.t${CDATEin:8:2}z.wrfnatf${fstr}.grib2
   # Interpolate to Lambert conformal grid
-  grid_specs_20km="lambert:-97.5:38.5 -133.174:449:20000.0 5.47114:299:20000.0"
-  ${WGRIB2} ${GRIB_FILE} -set_bitmap 1 -set_grib_type c3 -new_grid_winds grid \
-	 -new_grid_vectors "UGRD:VGRD:USTM:VSTM:VUCSH:VVCSH"               \
-	 -new_grid_interpolation neighbor                                  \
-	 -new_grid ${grid_specs_20km} tmp.grib2
-  # Merge vector field records
-  ${WGRIB2} tmp.grib2 -new_grid_vectors "UGRD:VGRD:USTM:VSTM:VUCSH:VVCSH" -submsg_uv 20km_grid.grib2
-  ln -snf 20km_grid.grib2 GRIBFILE.AAA
+  if true; then #gge.debug need to confirm when to do an interpolation for RAP and RRFS
+    ln -snf ${GRIBFILE} GRIBFILE.AAA
+  else
+    grid_specs_20km="lambert:-97.5:38.5 -133.174:449:20000.0 5.47114:299:20000.0"
+    ${WGRIB2} ${GRIBFILE} -set_bitmap 1 -set_grib_type c3 -new_grid_winds grid \
+           -new_grid_vectors "UGRD:VGRD:USTM:VSTM:VUCSH:VVCSH"               \
+           -new_grid_interpolation neighbor                                  \
+           -new_grid ${grid_specs_20km} tmp.grib2
+    # Merge vector field records
+    ${WGRIB2} tmp.grib2 -new_grid_vectors "UGRD:VGRD:USTM:VSTM:VUCSH:VVCSH" -submsg_uv 20km_grid.grib2
+    ln -snf 20km_grid.grib2 GRIBFILE.AAA
+  fi #skip preprocessing
 
 elif [[ "${prefix}" == "RRFS" ]]; then
   fstr=$(printf %02d ${FHRin})
-  GRIB_FILE=${COMINrrfs1}/rrfs_a.${CDATEin:0:8}/${CDATEin:8:2}/rrfs.t${CDATEin:8:2}z.natlve.f${fstr}.grib2
+  GRIBFILE=${COMINrrfs1}/rrfs_a.${CDATEin:0:8}/${CDATEin:8:2}/rrfs.t${CDATEin:8:2}z.natlve.f${fstr}.grib2
   # variation on the 130 grid at 3 km
   grid_specs="lambert:266:25.000000 234.862000:2000:3000.000000 17.281000:1480:3000.000000"
-  ${WGRIB2} ${GRIB_FILE} -set_bitmap 1 -set_grib_type c3 -new_grid_winds grid \
+  ${WGRIB2} ${GRIBFILE} -set_bitmap 1 -set_grib_type c3 -new_grid_winds grid \
 	 -new_grid_vectors "UGRD:VGRD:USTM:VSTM:VUCSH:VVCSH"               \
 	 -new_grid_interpolation bilinear \
 	 -if "`cat ${FIXrrfs}/ungrib/budget_fields.txt`" -new_grid_interpolation budget -fi \

--- a/workflow/config/resources/config.base
+++ b/workflow/config/resources/config.base
@@ -22,14 +22,14 @@ export NODES_DA=${NODES_DA:-"<nodes>1:ppn=40</nodes>"}
 export NODES_FCST=${NODES_FCST:-"<nodes>3:ppn=40</nodes>"}
 export WALLTIME_FCST=${WALLTIME_FCST:-"00:50:00"}
 
-# upp
-export NODES_UPP="<nodes>2:ppn=40</nodes>"
-export WALLTIME_UPP="00:50:00"
-export NATIVE_UPP="--exclusive"
-
 # mpassit
 export NODES_MPASSIT=${NODES_MPASSIT:-"<nodes>2:ppn=40</nodes>"}
 export WALLTIME_MPASSIT=${WALLTIME_MPASSIT:-"00:50:00"}
+
+# upp
+export NODES_UPP=${NODES_UPP:-"<nodes>2:ppn=40</nodes>"}
+export WALLTIME_UPP=${WALLTIME_UPP:-"00:50:00"}
+export NATIVE_UPP=${NATIVE_UPP:-"--exclusive"}
 
 # graphics
 export NODES_GRAPHICS="<nodes>1:ppn=20</nodes>"
@@ -37,8 +37,8 @@ export WALLTIME_GRAPHICS="04:00:00"
 export NATIVE_GRAPHICS="--exclusive"
 
 # clean
-export ACCOUNT_CLEAN=${ACCOUNT2:$ACCOUNT}
-export QUEUE_CLEAN=${QUEUE2:$QUEUE}
-export PARTITION_CLEAN=${PARTITION2:$PATITION}
+export ACCOUNT_CLEAN=${ACCOUNT2:-$ACCOUNT}
+export QUEUE_CLEAN=${QUEUE2:-$QUEUE}
+export PARTITION_CLEAN=${PARTITION2:-$PATITION}
 export RESERVATION_CLEAN=""
 export NODES_CLEAN="<nodes>1:ppn=1</nodes>"

--- a/workflow/config/resources/config.pre.jet_hrrrv5
+++ b/workflow/config/resources/config.pre.jet_hrrrv5
@@ -21,4 +21,7 @@ export STARTTIME_UPP="00:00:01"
 export NODES_FCST="<nodes>40:ppn=20</nodes>"
 export NODES_IC="<nodes>40:ppn=20</nodes>"
 export NODES_LBC="<nodes>40:ppn=20</nodes>"
+export NODES_MPASSIT="<nodes>4:ppn=20</nodes>"
+export NODES_UPP="<nodes>4:ppn=20</nodes>"
 #
+export WALLTIME_FCST="4:00:00"

--- a/workflow/xml_funcs/tasks1.py
+++ b/workflow/xml_funcs/tasks1.py
@@ -114,7 +114,7 @@ def da(xmlFile, expdir):
         <or>
 {strneqs}
         </or>
-        <datadep age="00:05:00"><cyclestr>{DATAROOT}/{NET}/{VERSION}/{RUN}.@Y@m@d/@H/fcst/</cyclestr><cyclestr offset="1:00:00">restart.@Y-@m-@d_@H.@M.@S.nc</cyclestr></datadep>
+        <datadep age="00:05:00"><cyclestr offset="-1:00:00">{DATAROOT}/{NET}/{VERSION}/{RUN}.@Y@m@d/@H/fcst/</cyclestr><cyclestr>restart.@Y-@m-@d_@H.@M.@S.nc</cyclestr></datadep>
       </and>
     </or>
   </and>


### PR DESCRIPTION
mpassit and upp needs more memory for hrrrv5 3km runs, so change from 2:ppn=40 to 4:ppn=20
fcst needs more walltime for hrrrv5 3km runs, change to 4:00:00
grid interpolation for RAP/RRFS only applies to some situations