### PR TITLE
Update MPASSIT

### DIFF
--- a/parm/rrfs/namelist.mpassit
+++ b/parm/rrfs/namelist.mpassit
@@ -2,10 +2,19 @@
     grid_file_input_grid = "mpassit.init.nc"
     hist_file_input_grid = "history.@timestr@.nc"
     diag_file_input_grid = "diag.@timestr@.nc"
-    file_target_grid     = "geo_em.d01.nc"
     output_file          = "mpassit.@timestr@.nc"
+    target_grid_type     = 'lambert'
     interp_diag          = .true.
     interp_hist          = .true.
     wrf_mod_vars         = .true.
-    esmf_log             = .false.
+    esmf_log             = .true.
+    nx = 480
+    ny = 280
+    dx = 12000.0
+    dy = 12000.0
+    ref_lat = 39.0
+    ref_lon = -97.5
+    truelat1 = 39.0
+    truelat2 = 39.0
+    stand_lon = -97.5
 /

--- a/parm/rrfs/namelist.mpassit
+++ b/parm/rrfs/namelist.mpassit
@@ -8,13 +8,13 @@
     interp_hist          = .true.
     wrf_mod_vars         = .true.
     esmf_log             = .false.
-    nx = 480
-    ny = 280
-    dx = 12000.0
-    dy = 12000.0
-    ref_lat = 39.0
+    nx = @nx@
+    ny = @ny@
+    dx = @dx@.0
+    dy = @dx@.0
+    ref_lat = @lat@.@lat2@
     ref_lon = -97.5
-    truelat1 = 39.0
-    truelat2 = 39.0
+    truelat1 = @lat@.@lat2@
+    truelat2 = @lat@.@lat2@
     stand_lon = -97.5
 /

--- a/parm/rrfs/namelist.mpassit
+++ b/parm/rrfs/namelist.mpassit
@@ -7,7 +7,7 @@
     interp_diag          = .true.
     interp_hist          = .true.
     wrf_mod_vars         = .true.
-    esmf_log             = .true.
+    esmf_log             = .false.
     nx = 480
     ny = 280
     dx = 12000.0

--- a/parm/rrfs/namelist.mpassit
+++ b/parm/rrfs/namelist.mpassit
@@ -10,11 +10,11 @@
     esmf_log             = .false.
     nx = @nx@
     ny = @ny@
-    dx = @dx@.0
-    dy = @dx@.0
-    ref_lat = @lat@.@lat2@
+    dx = @dx@
+    dy = @dx@
+    ref_lat = @ref_lat@
     ref_lon = -97.5
-    truelat1 = @lat@.@lat2@
-    truelat2 = @lat@.@lat2@
+    truelat1 = @ref_lat@
+    truelat2 = @ref_lat@
     stand_lon = -97.5
 /

--- a/scripts/exrrfs_mpassit.sh
+++ b/scripts/exrrfs_mpassit.sh
@@ -15,18 +15,16 @@ ${cpreq} ${FIXrrfs}/mpassit/${NET}/* .
 if [[ "${NET}" == "conus12km" ]]; then
   nx=480
   ny=280
-  dx=12000
-  lat=39
-  lat2=0
+  dx=12000.0
+  ref_lat=39.0
 elif [[ "${NET}" == "conus3km" ]]; then
   nx=1601
   ny=961
-  dx=3000
-  lat=38
-  lat2=5
+  dx=3000.0
+  ref_lat=38.5
 fi
 sed -e "s/@timestr@/${timestr}/" -e "s/@nx@/${nx}/" -e "s/@ny@/${ny}/" -e "s/@dx@/${dx}/" \
-    -e "s/@lat@/${lat}/" -e "s/@lat2@/${lat2}/" ${PARMrrfs}/rrfs/namelist.mpassit > namelist.mpassit
+    -e "s/@ref_lat@/${ref_lat}/" ${PARMrrfs}/rrfs/namelist.mpassit > namelist.mpassit
 
 # run the MPAS model
 ulimit -s unlimited

--- a/scripts/exrrfs_mpassit.sh
+++ b/scripts/exrrfs_mpassit.sh
@@ -12,7 +12,21 @@ ${cpreq} ${DATAROOT}/${NET}/${rrfs_ver}/${RUN}.${PDY}/${cyc}/fcst/history.${time
 ${cpreq} ${DATAROOT}/${NET}/${rrfs_ver}/${RUN}.${PDY}/${cyc}/fcst/diag.${timestr}.nc .
 ${cpreq} ${FIXrrfs}/mpassit/${NET}/* .
 # generate the namelist on the fly
-sed -e "s/@timestr@/${timestr}/" ${PARMrrfs}/rrfs/namelist.mpassit > namelist.mpassit
+if [[ "${NET}" == "conus12km" ]]; then
+  nx=480
+  ny=280
+  dx=12000
+  lat=39
+  lat2=0
+elif [[ "${NET}" == "conus3km" ]]; then
+  nx=1601
+  ny=961
+  dx=3000
+  lat=38
+  lat2=5
+fi
+sed -e "s/@timestr@/${timestr}/" -e "s/@nx@/${nx}/" -e "s/@ny@/${ny}/" -e "s/@dx@/${dx}/" \
+    -e "s/@lat@/${lat}/" -e "s/@lat2@/${lat2}/" ${PARMrrfs}/rrfs/namelist.mpassit > namelist.mpassit
 
 # run the MPAS model
 ulimit -s unlimited
@@ -37,8 +51,7 @@ module list
 set -x  
 ### temporarily solution since mpassit uses different modules files that other components
 source prep_step
-#srun /lfs5/BMC/nrtrr/FIX_RRFS2/exec/mpassit.x namelist.mpassit  #gge.debug temp solution
-srun /lfs4/BMC/wrfruc/ejames/MPASSIT/bin/mpassit namelist.mpassit
+srun /lfs5/BMC/nrtrr/FIX_RRFS2/exec/mpassit_20240801.x namelist.mpassit
 # check the status copy output to COMOUT
 if [[ -s "./mpassit.${timestr}.nc" ]]; then
   ${cpreq} ${DATA}/${FHR}/mpassit.${timestr}.nc ${COMOUT}/${task_id}/

--- a/scripts/exrrfs_mpassit.sh
+++ b/scripts/exrrfs_mpassit.sh
@@ -37,7 +37,8 @@ module list
 set -x  
 ### temporarily solution since mpassit uses different modules files that other components
 source prep_step
-srun /lfs5/BMC/nrtrr/FIX_RRFS2/exec/mpassit.x namelist.mpassit  #gge.debug temp solution
+#srun /lfs5/BMC/nrtrr/FIX_RRFS2/exec/mpassit.x namelist.mpassit  #gge.debug temp solution
+srun /lfs4/BMC/wrfruc/ejames/MPASSIT/bin/mpassit namelist.mpassit
 # check the status copy output to COMOUT
 if [[ -s "./mpassit.${timestr}.nc" ]]; then
   ${cpreq} ${DATA}/${FHR}/mpassit.${timestr}.nc ${COMOUT}/${task_id}/


### PR DESCRIPTION
This PR updates to the latest version of MPASSIT from github.  This gets rid of the x/y streak issue for the u/v variables, and also allows us to remove dependency on geo_em.d01.nc file.